### PR TITLE
BatoTo | 3.0.3 - Fix script regex for image key

### DIFF
--- a/src/BatoTo/BatoTo.ts
+++ b/src/BatoTo/BatoTo.ts
@@ -1,5 +1,4 @@
 import {
-    BadgeColor,
     Chapter,
     ChapterDetails,
     ChapterProviding,
@@ -34,7 +33,7 @@ import {
 const BATO_DOMAIN = 'https://bato.to'
 
 export const BatoToInfo: SourceInfo = {
-    version: '3.0.2',
+    version: '3.0.3',
     name: 'BatoTo',
     icon: 'icon.png',
     author: 'Nicholas',

--- a/src/BatoTo/BatoToParser.ts
+++ b/src/BatoTo/BatoToParser.ts
@@ -139,7 +139,7 @@ export const parseChapterDetails = ($: CheerioStatic, mangaId: string, chapterId
 
     const batoPass = eval(script.match(/const\s+batoPass\s*=\s*(.*?);/)?.[1] ?? '').toString()
     const batoWord = (script.match(/const\s+batoWord\s*=\s*"(.*)";/)?.[1] ?? '')
-    const imgList = JSON.parse(script.match(/const\s+imgHttpLis\s*=\s*(.*?);/)?.[1] ?? '')
+    const imgList = JSON.parse(script.match(/const\s+imgHttps\s*=\s*(.*?);/)?.[1] ?? '')
     const tknList = JSON.parse(CryptoJS.AES.decrypt(batoWord, batoPass).toString(CryptoJS.enc.Utf8))
 
     for (let i = 0; i < Math.min(imgList.length, tknList.length); i++) {


### PR DESCRIPTION
Discovered all that yapping was actually an issue. BatoTo replaced variable names in their decoder script.