### PR TITLE
MangaDex | 3.0.3 - Fix weird quirk with search query

### DIFF
--- a/src/MangaDex/MangaDex.ts
+++ b/src/MangaDex/MangaDex.ts
@@ -64,7 +64,7 @@ export const MangaDexInfo: SourceInfo = {
     description: 'Extension that pulls manga from MangaDex',
     icon: 'icon.png',
     name: 'MangaDex',
-    version: '3.0.2',
+    version: '3.0.3',
     authorWebsite: 'https://github.com/nar1n',
     websiteBaseURL: MANGADEX_DOMAIN,
     contentRating: ContentRating.EVERYONE,
@@ -358,7 +358,7 @@ export class MangaDex implements ChapterProviding, SearchResultsProviding, HomeP
 
         const url = new URLBuilder(this.MANGADEX_API)
             .addPathComponent('manga')
-            .addQueryParameter(searchType, (query.title?.length ?? 0) > 0 ? encodeURIComponent(query.title!) : undefined)
+            .addQueryParameter(searchType, (query.title?.length ?? 0) > 0 ? encodeURIComponent(query.title!).replace(/%20/g, '+') : undefined)
             .addQueryParameter('limit', 100)
             .addQueryParameter('hasAvailableChapters', true)
             .addQueryParameter('availableTranslatedLanguage', languages)


### PR DESCRIPTION
Not sure why requestManager does not deal with %20 (aka spaces) properly