### PR TITLE
MangaDex | Remove search query "hack"

### DIFF
--- a/src/MangaDex/MangaDex.ts
+++ b/src/MangaDex/MangaDex.ts
@@ -64,7 +64,7 @@ export const MangaDexInfo: SourceInfo = {
     description: 'Extension that pulls manga from MangaDex',
     icon: 'icon.png',
     name: 'MangaDex',
-    version: '3.0.3',
+    version: '3.0.4',
     authorWebsite: 'https://github.com/nar1n',
     websiteBaseURL: MANGADEX_DOMAIN,
     contentRating: ContentRating.EVERYONE,

--- a/src/MangaDex/MangaDex.ts
+++ b/src/MangaDex/MangaDex.ts
@@ -358,7 +358,7 @@ export class MangaDex implements ChapterProviding, SearchResultsProviding, HomeP
 
         const url = new URLBuilder(this.MANGADEX_API)
             .addPathComponent('manga')
-            .addQueryParameter(searchType, (query.title?.length ?? 0) > 0 ? encodeURIComponent(query.title!).replace(/%20/g, '+') : undefined)
+            .addQueryParameter(searchType, (query.title?.length ?? 0) > 0 ? query.title : undefined)
             .addQueryParameter('limit', 100)
             .addQueryParameter('hasAvailableChapters', true)
             .addQueryParameter('availableTranslatedLanguage', languages)


### PR DESCRIPTION
URL taken in createRequest runs encodeURI again,
which causes the query to be encoded twice.

In this case, spaces are encoded as %20 the first run of encoudeURI, and then %2520 the second run where %25 replaces the original % in %20.