### PR TITLE
Mangadex: Fix Buffer undefined issue with Base64

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@paperback/toolchain": "^0.8.7",
     "@paperback/types": "^0.8.7",
     "cheerio": "^1.0.0",
-    "html-entities": "^2.5.2"
+    "html-entities": "^2.5.2",
+    "js-base64": "^3.7.7"
   }
 }

--- a/src/MangaDex/MangaDex.ts
+++ b/src/MangaDex/MangaDex.ts
@@ -64,7 +64,7 @@ export const MangaDexInfo: SourceInfo = {
     description: 'Extension that pulls manga from MangaDex',
     icon: 'icon.png',
     name: 'MangaDex',
-    version: '3.0.5',
+    version: '3.0.6',
     authorWebsite: 'https://github.com/nar1n',
     websiteBaseURL: MANGADEX_DOMAIN,
     contentRating: ContentRating.EVERYONE,

--- a/src/MangaDex/MangaDexSettings.ts
+++ b/src/MangaDex/MangaDexSettings.ts
@@ -7,7 +7,7 @@ import {
     MDRatings,
     MDImageQuality
 } from './MangaDexHelper'
-
+import { Base64 } from 'js-base64'
 
 export async function getLanguages(stateManager: SourceStateManager) {
     return (await stateManager.retrieve('languages') ?? MDLanguages.getDefault())
@@ -152,7 +152,7 @@ export async function parseAccessToken(accessToken: string | undefined) {
     const tokenBodyBase64 = accessToken.split('.')[1]
     if (!tokenBodyBase64) return undefined
 
-    const tokenBodyJSON = Buffer.from(tokenBodyBase64, 'base64').toString('ascii')
+    const tokenBodyJSON = Base64.decode(tokenBodyBase64)
     return JSON.parse(tokenBodyJSON)
 }
 


### PR DESCRIPTION
Mangadex randomly broke for me and 0.9 isn't iPad ready, so here's a fix. Tested on iPhone 15 Pro Max and iPad Pro M4 using iOS 18.3 public beta. Can test using github pages from my fork, just add 0.8 to the end. 

Fixes Issue #62 