### PR TITLE
MangaDex | Fix title logic

### DIFF
--- a/src/MangaDex/MangaDexParser.ts
+++ b/src/MangaDex/MangaDexParser.ts
@@ -9,7 +9,7 @@ export const parseMangaList = async (object: MangaItem[], source: any, thumbnail
     for (const manga of object) {
         const mangaId = manga.id
         const mangaDetails = manga.attributes
-        const title = source.decodeHTMLEntity(mangaDetails.title.en ?? mangaDetails.altTitles.map(x => Object.values(x).find((v) => v !== undefined)).find((t) => t !== undefined))
+        const title = source.decodeHTMLEntity(mangaDetails.title.en ?? Object.values(mangaDetails.title)[0] ?? mangaDetails.altTitles.map(x => Object.values(x).find((v) => v !== undefined)).find((t) => t !== undefined)) ?? 'INVALID TITLE'
         const coverFileName = manga.relationships.filter((x) => x.type == 'cover_art').map((x) => x.attributes?.fileName)[0]
         const image = coverFileName ? `${source.COVER_BASE_URL}/${mangaId}/${coverFileName}${MDImageQuality.getEnding(await thumbnailSelector(source.stateManager))}` : 'https://mangadex.org/_nuxt/img/cover-placeholder.d12c3c5.jpg'
         const subtitle = `${mangaDetails.lastVolume ? `Vol. ${mangaDetails.lastVolume}` : ''} ${mangaDetails.lastChapter ? `Ch. ${mangaDetails.lastChapter}` : ''}`


### PR DESCRIPTION
The title parser was returning undefined because the title isn't `en` (e.g `ja-ro`) and there were no alternate titles for the series. Example series: https://mangadex.org/title/a41b5a2b-9dc5-4e9c-bafd-f614eeeaae3b
This results in the homepage and its expanded sections failing entirely when a series fulfills this requirement.

I have another commit on a personal branch, https://github.com/OTCompa/paperback-extensions/commit/509d92061f22fdb5ff4a72600414fff2448a040b, that fixes the source settings menu based on advice from https://github.com/TheNetsky/community-extensions/issues/62#issuecomment-2508857268. I'm not very versed in how things are done around here, let alone JS/TS but if that looks good I'll add it to this PR too.