### PR TITLE
MangaDex | Fix missing Buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@paperback/toolchain": "^0.8.7",
     "@paperback/types": "^0.8.7",
+    "buffer": "^6.0.3",
     "cheerio": "^1.0.0",
     "html-entities": "^2.5.2"
   }

--- a/src/MangaDex/MangaDex.ts
+++ b/src/MangaDex/MangaDex.ts
@@ -64,7 +64,7 @@ export const MangaDexInfo: SourceInfo = {
     description: 'Extension that pulls manga from MangaDex',
     icon: 'icon.png',
     name: 'MangaDex',
-    version: '3.0.5',
+    version: '3.0.6',
     authorWebsite: 'https://github.com/nar1n',
     websiteBaseURL: MANGADEX_DOMAIN,
     contentRating: ContentRating.EVERYONE,

--- a/src/MangaDex/MangaDexSettings.ts
+++ b/src/MangaDex/MangaDexSettings.ts
@@ -7,7 +7,9 @@ import {
     MDRatings,
     MDImageQuality
 } from './MangaDexHelper'
-
+import {
+    Buffer
+} from 'buffer'
 
 export async function getLanguages(stateManager: SourceStateManager) {
     return (await stateManager.retrieve('languages') ?? MDLanguages.getDefault())


### PR DESCRIPTION
Fixes #62, The following error that appears in multiple places and also renders the source settings unusable: <img width="1170" height="462" alt="image" src="https://github.com/user-attachments/assets/2211aca6-58a1-48d8-9ceb-738bcc339141" />

As mentioned in #74, figured I should just send a PR for this too
> I have another commit on a personal branch, https://github.com/OTCompa/paperback-extensions/commit/509d92061f22fdb5ff4a72600414fff2448a040b, that fixes the source settings menu based on advice from https://github.com/TheNetsky/community-extensions/issues/62#issuecomment-2508857268. I'm not very versed in how things are done around here, let alone JS/TS but if that looks good I'll add it to this PR too.
