### PR TITLE
NHentai | Switch to API v2 + Rate Limit Handling

### DIFF
--- a/src/NHentai/NHentai.ts
+++ b/src/NHentai/NHentai.ts
@@ -41,9 +41,10 @@ import {
 import { popularTags } from './tags.json'
 
 const NHENTAI_URL = 'https://nhentai.net'
+const MAX_RATE_LIMIT_RETRIES = 3
 
 export const NHentaiInfo: SourceInfo = {
-    version: '4.0.9',
+    version: '4.1.0',
     name: 'nhentai',
     icon: 'icon.png',
     author: 'NotMarek & Netsky',
@@ -63,7 +64,7 @@ export const NHentaiInfo: SourceInfo = {
 
 export class NHentai implements SearchResultsProviding, MangaProviding, ChapterProviding, HomePageSectionsProviding {
     readonly requestManager: RequestManager = App.createRequestManager({
-        requestsPerSecond: 3,
+        requestsPerSecond: 1,
         requestTimeout: 15000,
         interceptor: {
             interceptRequest: async (request: Request): Promise<Request> => {
@@ -99,39 +100,67 @@ export class NHentai implements SearchResultsProviding, MangaProviding, ChapterP
 
     getMangaShareUrl(mangaId: string): string { return `${NHENTAI_URL}/g/${mangaId}` }
 
+    async scheduleRequest(request: Request, priority: number): Promise<Response> {
+        let response = await this.requestManager.schedule(request, priority)
+
+        for (let i = 0; i < MAX_RATE_LIMIT_RETRIES; i++) {
+            if (response.status != 429) {
+                return response
+            }
+
+            response = await this.requestManager.schedule(request, priority)
+        }
+
+        return response
+    }
+
+    throwApiError(status: number, jsonData?: any): void {
+        if (status == 429 || jsonData?.error == 'Rate limit exceeded') {
+            throw new Error('RATE LIMIT ERROR:\nnhentai API rate limit exceeded. Please wait about 1 minute and try again.')
+        }
+
+        if (status >= 400) {
+            const errorMessage = typeof jsonData?.error == 'string' ? jsonData.error : `Request failed with status ${status}`
+            throw new Error(`NHENTAI API ERROR:\n${errorMessage}`)
+        }
+    }
+
     async getMangaDetails(mangaId: string): Promise<SourceManga> {
         const request = App.createRequest({
-            url: `${NHENTAI_URL}/api/gallery/${mangaId}`,
+            url: `${NHENTAI_URL}/api/v2/galleries/${mangaId}`,
             method: 'GET'
         })
-        const response = await this.requestManager.schedule(request, 1)
+        const response = await this.scheduleRequest(request, 1)
         this.CloudFlareError(response.status)
 
         const jsonData = this.parseJson(response)
+        this.throwApiError(response.status, jsonData)
         return parseMangaDetails(jsonData)
     }
 
     async getChapters(mangaId: string): Promise<Chapter[]> {
         const request = App.createRequest({
-            url: `${NHENTAI_URL}/api/gallery/${mangaId}`,
+            url: `${NHENTAI_URL}/api/v2/galleries/${mangaId}`,
             method: 'GET'
         })
-        const response = await this.requestManager.schedule(request, 1)
+        const response = await this.scheduleRequest(request, 1)
         this.CloudFlareError(response.status)
 
         const jsonData = this.parseJson(response)
+        this.throwApiError(response.status, jsonData)
         return [parseChapters(jsonData, mangaId)]
     }
 
     async getChapterDetails(mangaId: string): Promise<ChapterDetails> {
         const request = App.createRequest({
-            url: `${NHENTAI_URL}/api/gallery/${mangaId}`,
+            url: `${NHENTAI_URL}/api/v2/galleries/${mangaId}`,
             method: 'GET'
         })
-        const response = await this.requestManager.schedule(request, 1)
+        const response = await this.scheduleRequest(request, 1)
         this.CloudFlareError(response.status)
 
         const jsonData = this.parseJson(response)
+        this.throwApiError(response.status, jsonData)
         return parseChapterDetails(jsonData, mangaId)
     }
 
@@ -163,13 +192,24 @@ export class NHentai implements SearchResultsProviding, MangaProviding, ChapterP
         // When given number query
         if (/^\d+$/.test(title)) {
             const request = App.createRequest({
-                url: `${NHENTAI_URL}/api/gallery/${title}`,
+                url: `${NHENTAI_URL}/api/v2/galleries/${title}`,
                 method: 'GET'
             })
-            const response = await this.requestManager.schedule(request, 1)
+            const response = await this.scheduleRequest(request, 1)
             this.CloudFlareError(response.status)
 
+            if (response.status == 404) {
+                return App.createPagedResults({
+                    results: [],
+                    metadata: {
+                        page: page,
+                        stopSearch: true
+                    }
+                })
+            }
+
             const jsonData = this.parseJson(response)
+            this.throwApiError(response.status, jsonData)
             return App.createPagedResults({
                 results: parseSearch({ result: [jsonData], num_pages: 1, per_page: 1 }),
                 metadata: {
@@ -183,13 +223,14 @@ export class NHentai implements SearchResultsProviding, MangaProviding, ChapterP
             const q: string = encodeURIComponent(`${title} ${query?.includedTags?.map((x: Tag) => ` +${x.id}`)} `) + await this.generateQuery()
 
             const request = App.createRequest({
-                url: `${NHENTAI_URL}/api/galleries/search?query=${(q)}&page=${page}&sort=${await this.sortOrder(this.stateManager)}`,
+                url: `${NHENTAI_URL}/api/v2/search?query=${(q)}&page=${page}&sort=${await this.sortOrder(this.stateManager)}`,
                 method: 'GET'
             })
-            const response = await this.requestManager.schedule(request, 1)
+            const response = await this.scheduleRequest(request, 1)
             this.CloudFlareError(response.status)
 
             const jsonData = this.parseJson(response)
+            this.throwApiError(response.status, jsonData)
             return App.createPagedResults({
                 results: parseSearch(jsonData),
                 metadata: {
@@ -203,7 +244,7 @@ export class NHentai implements SearchResultsProviding, MangaProviding, ChapterP
         const sections = [
             {
                 request: App.createRequest({
-                    url: `${NHENTAI_URL}/api/galleries/search?query=${await this.generateQuery()}&sort=date`,
+                    url: `${NHENTAI_URL}/api/v2/search?query=${await this.generateQuery()}&sort=date`,
                     method: 'GET'
                 }),
                 sectionID: App.createHomeSection({
@@ -215,7 +256,7 @@ export class NHentai implements SearchResultsProviding, MangaProviding, ChapterP
             },
             {
                 request: App.createRequest({
-                    url: `${NHENTAI_URL}/api/galleries/search?query=${await this.generateQuery()}&sort=popular-today`,
+                    url: `${NHENTAI_URL}/api/v2/search?query=${await this.generateQuery()}&sort=popular-today`,
                     method: 'GET'
                 }),
                 sectionID: App.createHomeSection({
@@ -227,7 +268,7 @@ export class NHentai implements SearchResultsProviding, MangaProviding, ChapterP
             },
             {
                 request: App.createRequest({
-                    url: `${NHENTAI_URL}/api/galleries/search?query=${await this.generateQuery()}&sort=popular-week`,
+                    url: `${NHENTAI_URL}/api/v2/search?query=${await this.generateQuery()}&sort=popular-week`,
                     method: 'GET'
                 }),
                 sectionID: App.createHomeSection({
@@ -239,7 +280,7 @@ export class NHentai implements SearchResultsProviding, MangaProviding, ChapterP
             },
             {
                 request: App.createRequest({
-                    url: `${NHENTAI_URL}/api/galleries/search?query=${await this.generateQuery()}&sort=popular-month`,
+                    url: `${NHENTAI_URL}/api/v2/search?query=${await this.generateQuery()}&sort=popular-month`,
                     method: 'GET'
                 }),
                 sectionID: App.createHomeSection({
@@ -251,7 +292,7 @@ export class NHentai implements SearchResultsProviding, MangaProviding, ChapterP
             },
             {
                 request: App.createRequest({
-                    url: `${NHENTAI_URL}/api/galleries/search?query=${await this.generateQuery()}&sort=popular`,
+                    url: `${NHENTAI_URL}/api/v2/search?query=${await this.generateQuery()}&sort=popular`,
                     method: 'GET'
                 }),
                 sectionID: App.createHomeSection({
@@ -268,10 +309,13 @@ export class NHentai implements SearchResultsProviding, MangaProviding, ChapterP
         for (const section of sections) {
             sectionCallback(section.sectionID)
             promises.push(
-                this.requestManager.schedule(section.request, 1)
+                this.scheduleRequest(section.request, 1)
                     .then(response => {
                         this.CloudFlareError(response.status)
                         const jsonData = this.parseJson(response)
+                        if (response.status >= 400) {
+                            return
+                        }
                         if (hasNoResults(jsonData)) {
                             return
                         }
@@ -288,13 +332,14 @@ export class NHentai implements SearchResultsProviding, MangaProviding, ChapterP
     async getViewMoreItems(homepageSectionId: string, metadata: any): Promise<PagedResults> {
         let page: number = metadata?.page ?? 1
         const request = App.createRequest({
-            url: `${NHENTAI_URL}/api/galleries/search?query=${await this.generateQuery()}&sort=${homepageSectionId}&page=${page}`,
+            url: `${NHENTAI_URL}/api/v2/search?query=${await this.generateQuery()}&sort=${homepageSectionId}&page=${page}`,
             method: 'GET'
         })
 
-        const response = await this.requestManager.schedule(request, 1)
+        const response = await this.scheduleRequest(request, 1)
         this.CloudFlareError(response.status)
         const jsonData = this.parseJson(response)
+        this.throwApiError(response.status, jsonData)
 
         page++
         return App.createPagedResults({
@@ -306,7 +351,7 @@ export class NHentai implements SearchResultsProviding, MangaProviding, ChapterP
     }
 
     CloudFlareError(status: number): void {
-        if (status == 503 || status == 403) {
+        if (status == 403) {
             throw new Error(`CLOUDFLARE BYPASS ERROR:\nPlease go to the homepage of <${NHentai.name}> and press the cloud icon.`)
         }
     }
@@ -328,7 +373,11 @@ export class NHentai implements SearchResultsProviding, MangaProviding, ChapterP
             return (typeof response.data == 'string') ? JSON.parse(response.data) : response.data
         } catch (error) {
             console.log(JSON.stringify(error))
-            throw new Error('JSON PARSE ERROR!\n\nYou\'ve like set too many filters in this source\'s settings, remove some to see results!')
+            if (response.status == 403 || response.status == 503) {
+                throw new Error(`CLOUDFLARE BYPASS ERROR:\nPlease go to the homepage of <${NHentai.name}> and press the cloud icon.`)
+            }
+
+            throw new Error('JSON PARSE ERROR!\n\nThe API returned an unexpected response. Please try again in a moment.')
         }
     }
 

--- a/src/NHentai/NHentaiInterfaces.ts
+++ b/src/NHentai/NHentaiInterfaces.ts
@@ -1,13 +1,30 @@
 
 export interface ImagePageObject {
-    t: 'j' | 'p' | 'g' | 'w';// JPG (≧◡≦)
+    t: 'j' | 'p' | 'g' | 'w';
     w: number;
     h: number;
 }
+
 export interface ImageObject {
     pages: ImagePageObject[];
     cover: ImagePageObject;
     thumbnail: ImagePageObject;
+}
+
+export interface CoverInfo {
+    path: string;
+    width: number;
+    height: number;
+}
+
+export interface PageInfo {
+    number: number;
+    path: string;
+    width: number;
+    height: number;
+    thumbnail: string;
+    thumbnail_width: number;
+    thumbnail_height: number;
 }
 
 export interface TagObject {
@@ -21,91 +38,52 @@ export interface TagObject {
     | 'parody'
     | 'tag';
     name: string;
+    slug?: string;
     url: string;
     count: number;
 }
 
 interface resTitleObj {
-    /**
-     * English title of this object.
-     *
-     * `eg: [Azuma Tesshin] Ichigo Cake to Mont Blanc | Strawberry Cake & Mont Blanc - The cherry boy with Bitch sister. (COMIC Kairakuten 2018-05) [English] [Tamamo | GDS] [Digital]"`
-     */
     english: string;
-    /**
-     * Native title of this object.
-     *
-     * `eg: [東鉄神] イチゴのケーキとモンブラン (COMIC 快楽天 2018年5月号) [英訳] [DL版]`
-     */
-    japanese: string;
-    /**
-     * Pretty title of this object.
-     *
-     * `eg: Ichigo Cake to Mont Blanc | Strawberry Cake & Mont Blanc - The cherry boy with Bitch sister.`
-     */
+    japanese: string | null;
     pretty: string;
 }
 
-export interface Gallery {
-    /**
-     * id of this object.
-     * `eg: 363636`
-     */
+export interface GalleryListItem {
     id: number;
-    /**
-     * mediaId of this object.
-     * `eg: 1940023`
-     */
     media_id: string;
-    /**
-     * Titles of this object.
-     */
+    thumbnail: string;
+    thumbnail_width: number;
+    thumbnail_height: number;
+    english_title: string;
+    japanese_title: string | null;
+    tag_ids: number[];
+}
+
+export interface Gallery {
+    id: number;
+    media_id: string;
     title: resTitleObj;
-    /**
-     * Images of this object.
-     */
-    images: ImageObject;
-    /**
-     * Scanlator of this object.
-     * Not available still. :-(
-     */
+    images?: ImageObject;
+    cover?: CoverInfo;
+    thumbnail?: CoverInfo;
     scanlator: string | undefined;
-    /**
-     * Uploaded date of this object in unix timestamp
-     */
     upload_date: number;
-    /**
-     * Tags of this object.
-     */
     tags: TagObject[];
-    /**
-     * Number of pages this object has.
-     */
     num_pages: number;
-    /**
-     * Number of favorites of this object in nhentai
-     */
     num_favorites: number;
+    pages?: PageInfo[];
 }
 
 export interface QueryResponse {
-    /**
-     * Array of {@link Gallery}
-     */
-    result: Gallery[];
-    /**
-     * Number of pages for this query.
-     * ``results = per_page * num_pages``
-     */
+    result: Array<GalleryListItem | Gallery>;
     num_pages: number;
-    /**
-     * Number of {@link Gallery} per page.
-     */
     per_page: number;
+    total?: number | null;
 }
 
 export interface RequestMetadata {
     nextPage?: number;
     maxPages?: number;
-    sort: 'popular-today' | 'popular-week' | 'popular-month' | 'popular' | '';
+    sort: 'date' | 'popular-today' | 'popular-week' | 'popular-month' | 'popular' | '';
 }

--- a/src/NHentai/NHentaiParser.ts
+++ b/src/NHentai/NHentaiParser.ts
@@ -10,10 +10,14 @@ import { NHLanguages } from './NHentaiHelper'
 
 import {
     Gallery,
+    GalleryListItem,
     ImagePageObject,
     QueryResponse,
     TagObject
 } from './NHentaiInterfaces'
+
+const IMAGE_SERVER = 'https://i4.nhentai.net'
+const THUMB_SERVER = 'https://t3.nhentai.net'
 
 export const parseMangaDetails = (data: Gallery): SourceManga => {
     const artist = getArtist(data)
@@ -28,10 +32,10 @@ export const parseMangaDetails = (data: Gallery): SourceManga => {
     return App.createSourceManga({
         id: data.id.toString(),
         mangaInfo: App.createMangaInfo({
-            titles: Object.values(data.title).filter(title => title !== null),
+            titles: Object.values(data.title).filter((title): title is string => title !== null && title !== ''),
             artist: artist,
             author: artist,
-            image: `https://t3.nhentai.net/galleries/${data.media_id}/cover.${typeOfImage(data.images.cover)}`,
+            image: getCoverImage(data),
             status: 'Completed',
             tags: [App.createTagSection({ id: 'tags', label: 'Tags', tags: tags })],
             desc: `Pages: ${data.num_pages} | Favorites: ${data.num_favorites}`
@@ -43,7 +47,7 @@ export const parseChapters = (data: Gallery, mangaId: string): Chapter => {
     return App.createChapter({
         id: mangaId,
         chapNum: 1,
-        name: data.title.english,
+        name: data.title.pretty || data.title.english,
         langCode: NHLanguages.getLangCode(getLanguage(data)),
         time: new Date(data.upload_date * 1000)
     })
@@ -53,10 +57,7 @@ export const parseChapterDetails = (data: Gallery, mangaId: string): ChapterDeta
     return App.createChapterDetails({
         id: mangaId,
         mangaId: mangaId,
-        pages: data.images.pages.map((image, i) => {
-            const type = typeOfImage(image)
-            return `https://i4.nhentai.net/galleries/${data.media_id}/${i + 1}.${type}`
-        })
+        pages: getPages(data)
     })
 }
 
@@ -64,21 +65,31 @@ export const parseSearch = (data: QueryResponse): PartialSourceManga[] => {
     const tiles: PartialSourceManga[] = []
     const collectedIds: string[] = []
 
+    if ((data as any)?.error) {
+        const errorMessage = (data as any).error
+        if (typeof errorMessage == 'string' && errorMessage.toLowerCase().includes('rate limit')) {
+            throw new Error('RATE LIMIT ERROR!\n\nnhentai API rate limit exceeded. Please wait about 1 minute and try again.')
+        }
+
+        throw new Error(`NHENTAI API ERROR!\n\n${errorMessage}`)
+    }
+
     if (!data?.result) {
         console.log(JSON.stringify(data))
-        throw new Error('JSON NO RESULT ERROR!\n\nYou\'ve like set too many additional arguments in this source\'s settings, remove some to see results!\nSo search with tags you need to use arguments like shown in the sourc\'s settings!')
+        throw new Error('JSON NO RESULT ERROR!\n\nThe API returned an unexpected response. Please try again in a moment.')
     }
 
     for (const gallery of data.result) {
+        const mangaId = gallery.id.toString()
+        if (collectedIds.includes(mangaId)) continue
 
-        if (collectedIds.includes(gallery.id.toString())) continue
         tiles.push(App.createPartialSourceManga({
-            image: `https://t3.nhentai.net/galleries/${gallery.media_id}/cover.${typeOfImage(gallery.images.cover)}`,
-            title: gallery.title.pretty,
-            mangaId: gallery.id.toString(),
-            subtitle: NHLanguages.getName(getLanguage(gallery)).substring(0, 3) + ' | Pgs: ' + gallery.num_pages
+            image: getSearchImage(gallery),
+            title: getSearchTitle(gallery),
+            mangaId: mangaId,
+            subtitle: getSearchSubtitle(gallery)
         }))
-        collectedIds.push(gallery.id.toString())
+        collectedIds.push(mangaId)
     }
     return tiles
 }
@@ -94,6 +105,69 @@ const typeMap: { [key: string]: string; } = { 'j': 'jpg', 'p': 'png', 'g': 'gif'
 
 const typeOfImage = (image: ImagePageObject): string => {
     return typeMap[image.t] ?? ''
+}
+
+const normalizePath = (path: string): string => {
+    return path.replace(/^\/+/, '')
+}
+
+const withBase = (base: string, path: string): string => {
+    return `${base}/${normalizePath(path)}`
+}
+
+const isGalleryListItem = (gallery: Gallery | GalleryListItem): gallery is GalleryListItem => {
+    return 'english_title' in gallery
+}
+
+const getCoverImage = (gallery: Gallery): string => {
+    if (gallery.cover?.path) {
+        return withBase(THUMB_SERVER, gallery.cover.path)
+    }
+
+    if (gallery.images?.cover) {
+        return `${THUMB_SERVER}/galleries/${gallery.media_id}/cover.${typeOfImage(gallery.images.cover)}`
+    }
+
+    return ''
+}
+
+const getPages = (gallery: Gallery): string[] => {
+    if (gallery.pages?.length) {
+        return gallery.pages.map(page => withBase(IMAGE_SERVER, page.path))
+    }
+
+    if (gallery.images?.pages?.length) {
+        return gallery.images.pages.map((image, i) => {
+            const type = typeOfImage(image)
+            return `${IMAGE_SERVER}/galleries/${gallery.media_id}/${i + 1}.${type}`
+        })
+    }
+
+    return []
+}
+
+const getSearchImage = (gallery: Gallery | GalleryListItem): string => {
+    if (isGalleryListItem(gallery)) {
+        return withBase(THUMB_SERVER, gallery.thumbnail)
+    }
+
+    return getCoverImage(gallery)
+}
+
+const getSearchTitle = (gallery: Gallery | GalleryListItem): string => {
+    if (isGalleryListItem(gallery)) {
+        return gallery.english_title || gallery.japanese_title || `Gallery ${gallery.id}`
+    }
+
+    return gallery.title.pretty || gallery.title.english || `Gallery ${gallery.id}`
+}
+
+const getSearchSubtitle = (gallery: Gallery | GalleryListItem): string => {
+    if (isGalleryListItem(gallery)) {
+        return ''
+    }
+
+    return `${NHLanguages.getName(getLanguage(gallery)).substring(0, 3)} | Pgs: ${gallery.num_pages}`
 }
 
 const getArtist = (gallery: Gallery): string => {


### PR DESCRIPTION
Migrates the NHentai extension to use the new API v2 endpoints, ensuring compatibility with the latest backend changes. Adds handling for API rate limits (429 errors). Error handling is improved to distinguish between rate limits, API errors, and Cloudflare bypass scenarios.