### PR TITLE
MangaPlus | Add random UUID as SESSION_TOKEN header

### DIFF
--- a/src/MangaPlus/MangaPlus.ts
+++ b/src/MangaPlus/MangaPlus.ts
@@ -31,6 +31,7 @@ import {
     resetSettings
 } from './MangaPlusSettings'
 
+
 const BASE_URL = 'https://mangaplus.shueisha.co.jp'
 const API_URL = 'https://jumpg-webapi.tokyo-cdn.com/api'
 
@@ -62,7 +63,8 @@ export class MangaPlus implements SearchResultsProviding, MangaProviding, Chapte
                     ...(request.headers ?? {}),
                     
                     'Referer': `${BASE_URL}/`,
-                    'user-agent': await this.requestManager.getDefaultUserAgent()
+                    'user-agent': await this.requestManager.getDefaultUserAgent(),
+                    'SESSION-TOKEN' : crypto.randomUUID()
                 }
 
                 if (request.url.startsWith('imageMangaId=')) {


### PR DESCRIPTION
This adapts the MangaPlus extension to the newest API changes.

I'm very much not familiar with PB or typescript. Did run the tests, got them to pass (and confirmed failing on the main branch). What I did not do is run any integration tests.

Debug log:

> [19:20:46:0996] # Time: 2656ms
[19:20:46:0996] 
[19:20:46:0996] Testing MangaPlus
[19:20:49:0891] # source should return homepage sections containing items: 2867ms
[19:20:50:0192] # source should return valid SourceManga definition: 301ms
[19:20:50:0492] # source should return some chapters: 301ms
[19:20:50:0804] # source should return chapter details with some pages: 311ms
[19:20:51:0189] # source should return some search results: 386ms

This might generate some suspicious traffic if a single user calls the API multiple times a minute with different session IDs each time