### PR TITLE
MangaDex | Expose available chapter languages

### DIFF
--- a/src/MangaDex/MangaDex.ts
+++ b/src/MangaDex/MangaDex.ts
@@ -229,7 +229,10 @@ export class MangaDex implements ChapterProviding, SearchResultsProviding, HomeP
                 artist,
                 desc: desc ?? 'No Description',
                 status,
-                tags: [App.createTagSection({ id: 'tags', label: 'Tags', tags: tags })]
+                tags: [App.createTagSection({ id: 'tags', label: 'Tags', tags: tags })],
+                additionalInfo: {
+                    availableTranslatedLanguages: mangaDetails.availableTranslatedLanguages.join(',')
+                }
             })
         })
     }


### PR DESCRIPTION
MangaDex returns the available translated languages for each series. This PR exposes it through the existing `MangaInfo.additionalInfo` metadata. 
  
This lets clients show only the languages available for a specific series but shouldn’t affect existing clients given its additive. 