### PR TITLE
MangaPlus | Migrate API responses to protobuf

### DIFF
--- a/src/MangaPlus/MangaPlus.ts
+++ b/src/MangaPlus/MangaPlus.ts
@@ -22,8 +22,10 @@ import {
 import {
     Language,
     MangaPlusResponse,
+    Title,
     TitleDetailView
 } from './MangaPlusHelper'
+import { decodeMangaPlusResponse } from './MangaPlusProto'
 
 import {
     contentSettings,
@@ -34,10 +36,8 @@ import {
 const BASE_URL = 'https://mangaplus.shueisha.co.jp'
 const API_URL = 'https://jumpg-webapi.tokyo-cdn.com/api'
 
-const langCode = Language.ENGLISH
-
 export const MangaPlusInfo: SourceInfo = {
-    version: '2.0.4',
+    version: '2.1.0',
     name: 'MangaPlus',
     icon: 'icon.png',
     author: 'Rinto-kun',
@@ -63,14 +63,18 @@ export class MangaPlus implements SearchResultsProviding, MangaProviding, Chapte
             return storedToken
         }
 
-        const sessionToken = crypto.randomUUID()
+        const sessionToken = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (character) => {
+            const random = Math.random() * 16 | 0
+            const value = character === 'x' ? random : (random & 0x3 | 0x8)
+            return value.toString(16)
+        })
         await this.stateManager.store('sessionToken', sessionToken)
         this.cachedSessionToken = sessionToken
         return sessionToken
     }
 
     requestManager = App.createRequestManager({
-        requestsPerSecond: 10,
+        requestsPerSecond: 5,
         requestTimeout: 20000,
         interceptor: {
             interceptRequest: async (request: Request): Promise<Request> => {
@@ -86,22 +90,21 @@ export class MangaPlus implements SearchResultsProviding, MangaProviding, Chapte
                     request.url = await this.getThumbnailUrl(mangaId)
                 }
 
+                const imageMetadata = this.getImageMetadata(request.url)
+                if (imageMetadata.viewToken) {
+                    request.headers = {
+                        ...request.headers,
+                        'Plus-Vw-Token': imageMetadata.viewToken
+                    }
+                }
+
                 return request
             },
             interceptResponse: async (response: Response): Promise<Response> => {
-                if (!response.request.url.includes('encryptionKey') && response.headers['Content-Type'] !== 'image/jpeg') {
-                    return response
-                }
+                const { encryptionKey } = this.getImageMetadata(response.request.url)
+                if (!encryptionKey || !response.rawData) return response
 
-                if (response.request.url.includes('title_thumbnail_portrait_list')) {
-                    return response
-                }
-
-                const encryptionKey = response.request.url.substring(response.request.url.lastIndexOf('#') + 1) ?? ''
-
-                // @ts-ignore
-                response.rawData = App.createRawData(this.decodeXoRCipher(App.createByteArray(response.rawData ?? new Uint8Array()), encryptionKey))
-
+                this.decodeXoRCipher(App.createByteArray(response.rawData), encryptionKey)
                 return response
             }
 
@@ -129,58 +132,43 @@ export class MangaPlus implements SearchResultsProviding, MangaProviding, Chapte
     getMangaShareUrl(mangaId: string): string { return `${BASE_URL}/titles/${mangaId}` }
 
     async getMangaDetails(mangaId: string): Promise<SourceManga> {
-        const request = App.createRequest({
-            url: `${API_URL}/title_detailV3?title_id=${mangaId}&format=json`,
-            method: 'GET'
-        })
-
-        const response = await this.requestManager.schedule(request, 1)
-        const result = TitleDetailView.fromJson(response.data as string)
-
-        return result.toSourceManga()
+        return (await this.getTitleDetail(mangaId)).toSourceManga()
     }
 
     private async getThumbnailUrl(mangaId: string): Promise<string> {
-        const request = App.createRequest({
-            url: `${API_URL}/title_detailV3?title_id=${mangaId}&format=json`,
-            method: 'GET'
-        })
-
-        const response = await this.requestManager.schedule(request, 1)
-        const result = TitleDetailView.fromJson(response.data as string)
-        
-        return result.title?.portraitImageUrl ?? ''
+        return (await this.getTitleDetail(mangaId)).title?.portraitImageUrl ?? ''
     }
 
     async getChapters(mangaId: string): Promise<Chapter[]> {
-        const request = App.createRequest({
-            url: `${API_URL}/title_detailV3?title_id=${mangaId}&format=json`,
-            method: 'GET'
-        })
-
-        const response = await this.requestManager.schedule(request, 1)
-        const result = TitleDetailView.fromJson(response.data as string)
-
-        return [...(result.firstChapterList ?? []), ...(result.lastChapterList ?? [])].reverse().filter(chapter => !chapter.isExpired).map(chapter => chapter.toSChapter())
+        const result = await this.getTitleDetail(mangaId)
+        return [...result.firstChapterList, ...result.lastChapterList]
+            .reverse()
+            .filter(chapter => !chapter.isExpired)
+            .map(chapter => chapter.toSChapter())
     }
 
     async getChapterDetails(mangaId: string, chapterId: string): Promise<ChapterDetails> {
         const request = App.createRequest({
-            url: `${API_URL}/manga_viewer?chapter_id=${chapterId}&split=${(await this.stateManager.retrieve('split_images')) as string ?? 'no'}&img_quality=${(await this.stateManager.retrieve('image_resolution')) as string ?? 'high'}&format=json`,
+            url: `${API_URL}/manga_viewer_v3?chapter_id=${chapterId}&split=${(await this.stateManager.retrieve('split_images')) as string ?? 'no'}&img_quality=${(await this.stateManager.retrieve('image_resolution')) as string ?? 'high'}&clang=eng`,
             method: 'GET'
         })
 
         const response = await this.requestManager.schedule(request, 1)
-        const result = JSON.parse(response.data as string) as MangaPlusResponse
+        const result = this.decodeResponse(response)
+        const success = this.getSuccess(result)
+        const viewer = success.mangaViewer
+        if (!viewer) throw new Error('Cannot find chapter')
 
-        if (result.success === undefined) {
-            throw new Error(result.error?.langPopup(Language.ENGLISH)?.body ?? 'Unknown error')
-        }
-
-        const pages = result.success.mangaViewer?.pages
+        const viewToken = encodeURIComponent(viewer.viewToken ?? '')
+        const pages = viewer.pages
             .map(page => page.mangaPage)
-            .filter(page => page)
-            .map((page) => page?.encryptionKey ? `${page?.imageUrl}#${page?.encryptionKey}` : '')
+            .filter((page): page is NonNullable<typeof page> => page !== undefined)
+            .map(page => {
+                const encryptionKey = page.encryptionKey ?? ''
+                return encryptionKey || viewToken
+                    ? `${page.imageUrl}#${encryptionKey}|${viewToken}`
+                    : page.imageUrl
+            })
 
         return App.createChapterDetails({
             id: chapterId,
@@ -192,89 +180,40 @@ export class MangaPlus implements SearchResultsProviding, MangaProviding, Chapte
 
     async getFeaturedTitles(): Promise<PartialSourceManga[]> {
         const request = App.createRequest({
-            url: `${API_URL}/featuredV2?lang=eng&clang=eng&format=json`,
+            url: `${API_URL}/featuredV2?lang=eng&clang=eng`,
             method: 'GET'
         })
 
         const response = await this.requestManager.schedule(request, 1)
-        const result = JSON.parse(response.data as string) as MangaPlusResponse
-
-        if (result.success === undefined) {
-            throw new Error(result.error?.langPopup(Language.ENGLISH)?.body ?? 'Unknown error')
-        }
+        const result = this.getSuccess(this.decodeResponse(response))
 
         const languages = await getLanguages(this.stateManager)
+        const lists = result.featuredTitlesViewV2?.contents
+            .map(content => content.titleList)
+            .filter((titleList): titleList is NonNullable<typeof titleList> => titleList !== undefined)
+        const featured = lists?.find(list => list.listName === 'WEEKLY SHONEN JUMP') ?? lists?.[0]
 
-        const results = result.success?.featuredTitlesViewV2?.contents?.find(x => x.titleList && x.titleList.listName == 'WEEKLY SHONEN JUMP')?.titleList.featuredTitles
-            .filter((title) => languages.includes(title.language ?? Language.ENGLISH))
-
-        const titles: PartialSourceManga[] = []
-        const collectedIds: string[] = []
-
-        for (const item of results ?? []) {
-            const mangaId = item.titleId.toString()
-            const title = item.name
-            const author = item.author
-            const image = item.portraitImageUrl
-
-            if (!mangaId || !title || collectedIds.includes(mangaId)) continue
-
-            titles.push(App.createPartialSourceManga({
-                mangaId: mangaId,
-                title: title,
-                subtitle: author,
-                image: image
-            }))
-        }
-
-        return titles
+        return this.createPartialTitles(featured?.featuredTitles ?? [], languages)
     }
 
     async getPopularTitles(): Promise<PartialSourceManga[]> {
         const request = App.createRequest({
-            url: `${API_URL}/title_list/ranking?format=json`,
+            url: `${API_URL}/title_list/rankingV2?lang=eng&type=hottest&clang=eng`,
             method: 'GET'
         })
 
         const response = await this.requestManager.schedule(request, 1)
-        const result = JSON.parse(response.data as string) as MangaPlusResponse
-
-        if (result.success === undefined) {
-            throw new Error(result.error?.langPopup(Language.ENGLISH)?.body ?? 'Unknown error')
-        }
+        const result = this.getSuccess(this.decodeResponse(response))
 
         const languages = await getLanguages(this.stateManager)
-
-        const results = result.success?.titleRankingView?.titles
-            .filter((title) => languages.includes(title.language ?? Language.ENGLISH))
-
-        const titles: PartialSourceManga[] = []
-        const collectedIds: string[] = []
-
-        for (const item of results ?? []) {
-            const mangaId = item.titleId.toString()
-            const title = item.name
-            const author = item.author
-            const image = item.portraitImageUrl
-
-            if (!mangaId || !title || collectedIds.includes(mangaId)) continue
-
-            titles.push(App.createPartialSourceManga({
-                mangaId: mangaId,
-                title: title,
-                subtitle: author,
-                image: image
-            }))
-        }
-
-        return titles
+        return this.createPartialTitles(result.titleRankingViewV2?.titles ?? [], languages)
     }
 
     async getLatestUpdates(): Promise<PartialSourceManga[]> {
 
         function latestUpdatesRequest() {
             return App.createRequest({
-                url: `${API_URL}/web/web_homeV4?lang=eng&format=json`,
+                url: `${API_URL}/web/web_homeV4?lang=eng&clang=eng`,
                 method: 'GET'
             })
         }
@@ -282,47 +221,23 @@ export class MangaPlus implements SearchResultsProviding, MangaProviding, Chapte
         const request = latestUpdatesRequest()
         const response = await this.requestManager.schedule(request, 1)
 
-        const result: MangaPlusResponse = JSON.parse(response.data as string)
-
-        if (result.success === undefined) {
-            throw new Error(result.error?.langPopup(langCode)?.body ?? 'Unknown error')
-        }
+        const result = this.getSuccess(this.decodeResponse(response))
 
         const languages = await getLanguages(this.stateManager)
 
-        const results = result.success.webHomeViewV4?.groups
-            .flatMap(ex => ex.titleGroups)
-            .flatMap(ex => ex.titles)
-            .map(title => title.title)
-            .filter(title => languages.includes(title.language ?? Language.ENGLISH))
+        const results = result.webHomeViewV4?.groups
+            .flatMap(group => group.titles)
+            .map(updatedTitle => updatedTitle.title)
+            .filter((title): title is Title => title !== undefined)
 
-        const titles: PartialSourceManga[] = []
-        const collectedIds: string[] = []
-
-        for (const item of results ?? []) {
-            const mangaId = item.titleId.toString()
-            const title = item.name
-            const author = item.author
-            const image = item.portraitImageUrl
-
-            if (!mangaId || !title || collectedIds.includes(mangaId)) continue
-
-            titles.push(App.createPartialSourceManga({
-                mangaId: mangaId,
-                title: title,
-                subtitle: author,
-                image: image
-            }))
-        }
-
-        return titles
+        return this.createPartialTitles(results ?? [], languages)
     }
 
     async getHomePageSections(sectionCallback: (section: HomeSection) => void): Promise<void> {
 
         const featuredSection = App.createHomeSection({
             id: 'featured',
-            title: 'Deatured',
+            title: 'Featured',
             containsMoreItems: true,
             type: HomeSectionType.featured,
             items: await this.getFeaturedTitles()
@@ -375,56 +290,94 @@ export class MangaPlus implements SearchResultsProviding, MangaProviding, Chapte
     }
 
     async getSearchResults(query: SearchRequest, metadata: any): Promise<PagedResults> {
-        const title = query.title ?? ''
-
         const request = App.createRequest({
-            url: `${API_URL}/title_list/allV2?format=JSON&${title ? 'filter=' + encodeURI(title) + '&' : ''}format=json`,
+            url: `${API_URL}/title_list/allV2`,
             method: 'GET'
         }
         )
 
         const response = await this.requestManager.schedule(request, 1)
-        const result = JSON.parse(response.data as string) as MangaPlusResponse
-
-        if (result.success === undefined) {
-            throw new Error(result.error?.langPopup(Language.ENGLISH)?.body ?? 'Unknown error')
-        }
+        const result = this.getSuccess(this.decodeResponse(response))
 
         const ltitle = query.title?.toLowerCase() ?? ''
         const languages = await getLanguages(this.stateManager)
 
-        const results = result.success?.allTitlesViewV2?.AllTitlesGroup.flatMap((group) => group.titles)
-            .filter((title) => languages.includes(title.language ?? Language.ENGLISH))
+        const results = result.allTitlesViewV2?.allTitlesGroup.flatMap(group => group.titles)
             .filter((title) => title.author?.toLowerCase().includes(ltitle) || title.name.toLowerCase().includes(ltitle))
 
-        const titles: PartialSourceManga[] = []
-        const collectedIds: string[] = []
-
-        for (const item of results ?? []) {
-            const mangaId = item.titleId.toString()
-            const title = item.name
-            const author = item.author
-            const image = item.portraitImageUrl
-
-            if (!mangaId || !title || collectedIds.includes(mangaId)) continue
-
-            titles.push(App.createPartialSourceManga({
-                mangaId: mangaId,
-                title: title,
-                subtitle: author,
-                image: image
-            }))
-        }
-
         return App.createPagedResults({
-            results: titles
+            results: this.createPartialTitles(results ?? [], languages)
         })
     }
 
     // Utility
-    private decodeXoRCipher(buffer: Uint8Array, encryptionKey: string) {
+    private async getTitleDetail(mangaId: string): Promise<TitleDetailView> {
+        const request = App.createRequest({
+            url: `${API_URL}/title_detailV3?title_id=${mangaId}&clang=eng`,
+            method: 'GET'
+        })
+
+        const response = await this.requestManager.schedule(request, 1)
+        const result = this.getSuccess(this.decodeResponse(response))
+        if (!result.titleDetailView?.title) throw new Error('Cannot find manga')
+
+        return result.titleDetailView
+    }
+
+    private decodeResponse(response: Response): MangaPlusResponse {
+        if (!response.rawData) throw new Error('Manga Plus returned an empty response')
+        return decodeMangaPlusResponse(App.createByteArray(response.rawData))
+    }
+
+    private getSuccess(result: MangaPlusResponse) {
+        if (!result.success) {
+            throw new Error(result.error?.langPopup(Language.ENGLISH)?.body ?? 'Unknown error')
+        }
+
+        return result.success
+    }
+
+    private createPartialTitles(items: Title[], languages: string[]): PartialSourceManga[] {
+        const collectedIds = new Set<string>()
+        const titles: PartialSourceManga[] = []
+
+        for (const item of items) {
+            const mangaId = item.titleId.toString()
+            if (!mangaId || !item.name || collectedIds.has(mangaId) || !languages.includes(item.language)) continue
+
+            collectedIds.add(mangaId)
+            titles.push(App.createPartialSourceManga({
+                mangaId,
+                title: item.name,
+                subtitle: item.author,
+                image: item.portraitImageUrl
+            }))
+        }
+
+        return titles
+    }
+
+    private getImageMetadata(url: string): { encryptionKey: string; viewToken: string } {
+        const fragmentIndex = url.lastIndexOf('#')
+        if (fragmentIndex < 0) return { encryptionKey: '', viewToken: '' }
+
+        const fragment = url.substring(fragmentIndex + 1)
+        const separator = fragment.match(/\||%7C/i)
+        if (separator?.index === undefined) return { encryptionKey: fragment, viewToken: '' }
+
+        const encryptionKey = fragment.substring(0, separator.index)
+        const encodedViewToken = fragment.substring(separator.index + separator[0].length)
+        return {
+            encryptionKey,
+            viewToken: encodedViewToken ? decodeURIComponent(encodedViewToken) : ''
+        }
+    }
+
+    private decodeXoRCipher(buffer: Uint8Array, encryptionKey: string): void {
         const key = encryptionKey.match(/../g)?.map((byte) => parseInt(byte, 16)) ?? []
 
-        return buffer.map((byte, index) => byte ^ (key[index % key.length] ?? 0))
+        for (let index = 0; index < buffer.length; index++) {
+            buffer[index] ^= key[index % key.length] ?? 0
+        }
     }
 }

--- a/src/MangaPlus/MangaPlus.ts
+++ b/src/MangaPlus/MangaPlus.ts
@@ -20,8 +20,10 @@ import {
 } from '@paperback/types'
 
 import {
+    getLanguageCode,
     Language,
     MangaPlusResponse,
+    SuccessResult,
     Title,
     TitleDetailView
 } from './MangaPlusHelper'
@@ -148,14 +150,15 @@ export class MangaPlus implements SearchResultsProviding, MangaProviding, Chapte
     }
 
     async getChapterDetails(mangaId: string, chapterId: string): Promise<ChapterDetails> {
+        const language = await this.getPreferredLanguage()
         const request = App.createRequest({
-            url: `${API_URL}/manga_viewer_v3?chapter_id=${chapterId}&split=${(await this.stateManager.retrieve('split_images')) as string ?? 'no'}&img_quality=${(await this.stateManager.retrieve('image_resolution')) as string ?? 'high'}&clang=eng`,
+            url: `${API_URL}/manga_viewer_v3?chapter_id=${chapterId}&split=${(await this.stateManager.retrieve('split_images')) as string ?? 'no'}&img_quality=${(await this.stateManager.retrieve('image_resolution')) as string ?? 'high'}&clang=${getLanguageCode(language)}`,
             method: 'GET'
         })
 
         const response = await this.requestManager.schedule(request, 1)
         const result = this.decodeResponse(response)
-        const success = this.getSuccess(result)
+        const success = this.getSuccess(result, language)
         const viewer = success.mangaViewer
         if (!viewer) throw new Error('Cannot find chapter')
 
@@ -179,58 +182,39 @@ export class MangaPlus implements SearchResultsProviding, MangaProviding, Chapte
     }
 
     async getFeaturedTitles(): Promise<PartialSourceManga[]> {
-        const request = App.createRequest({
-            url: `${API_URL}/featuredV2?lang=eng&clang=eng`,
-            method: 'GET'
+        const { languages, results } = await this.getResultsByLanguage(
+            languageCode => `${API_URL}/featuredV2?lang=${languageCode}&clang=${languageCode}`
+        )
+        const featuredTitles = results.flatMap(result => {
+            const lists = result.featuredTitlesViewV2?.contents
+                .map(content => content.titleList)
+                .filter((titleList): titleList is NonNullable<typeof titleList> => titleList !== undefined)
+            const featured = lists?.find(list => list.listName === 'WEEKLY SHONEN JUMP') ?? lists?.[0]
+            return featured?.featuredTitles ?? []
         })
 
-        const response = await this.requestManager.schedule(request, 1)
-        const result = this.getSuccess(this.decodeResponse(response))
-
-        const languages = await getLanguages(this.stateManager)
-        const lists = result.featuredTitlesViewV2?.contents
-            .map(content => content.titleList)
-            .filter((titleList): titleList is NonNullable<typeof titleList> => titleList !== undefined)
-        const featured = lists?.find(list => list.listName === 'WEEKLY SHONEN JUMP') ?? lists?.[0]
-
-        return this.createPartialTitles(featured?.featuredTitles ?? [], languages)
+        return this.createPartialTitles(featuredTitles, languages)
     }
 
     async getPopularTitles(): Promise<PartialSourceManga[]> {
-        const request = App.createRequest({
-            url: `${API_URL}/title_list/rankingV2?lang=eng&type=hottest&clang=eng`,
-            method: 'GET'
-        })
-
-        const response = await this.requestManager.schedule(request, 1)
-        const result = this.getSuccess(this.decodeResponse(response))
-
-        const languages = await getLanguages(this.stateManager)
-        return this.createPartialTitles(result.titleRankingViewV2?.titles ?? [], languages)
+        const { languages, results } = await this.getResultsByLanguage(
+            languageCode => `${API_URL}/title_list/rankingV2?lang=${languageCode}&type=hottest&clang=${languageCode}`
+        )
+        const titles = results.flatMap(result => result.titleRankingViewV2?.titles ?? [])
+        return this.createPartialTitles(titles, languages)
     }
 
     async getLatestUpdates(): Promise<PartialSourceManga[]> {
-
-        function latestUpdatesRequest() {
-            return App.createRequest({
-                url: `${API_URL}/web/web_homeV4?lang=eng&clang=eng`,
-                method: 'GET'
-            })
-        }
-
-        const request = latestUpdatesRequest()
-        const response = await this.requestManager.schedule(request, 1)
-
-        const result = this.getSuccess(this.decodeResponse(response))
-
-        const languages = await getLanguages(this.stateManager)
-
-        const results = result.webHomeViewV4?.groups
+        const { languages, results } = await this.getResultsByLanguage(
+            languageCode => `${API_URL}/web/web_homeV4?lang=${languageCode}&clang=${languageCode}`
+        )
+        const titles = results.flatMap(result => result.webHomeViewV4?.groups
             .flatMap(group => group.titles)
             .map(updatedTitle => updatedTitle.title)
             .filter((title): title is Title => title !== undefined)
+            ?? [])
 
-        return this.createPartialTitles(results ?? [], languages)
+        return this.createPartialTitles(titles, languages)
     }
 
     async getHomePageSections(sectionCallback: (section: HomeSection) => void): Promise<void> {
@@ -290,6 +274,7 @@ export class MangaPlus implements SearchResultsProviding, MangaProviding, Chapte
     }
 
     async getSearchResults(query: SearchRequest, metadata: any): Promise<PagedResults> {
+        const languages = await getLanguages(this.stateManager)
         const request = App.createRequest({
             url: `${API_URL}/title_list/allV2`,
             method: 'GET'
@@ -297,10 +282,9 @@ export class MangaPlus implements SearchResultsProviding, MangaProviding, Chapte
         )
 
         const response = await this.requestManager.schedule(request, 1)
-        const result = this.getSuccess(this.decodeResponse(response))
+        const result = this.getSuccess(this.decodeResponse(response), languages[0])
 
         const ltitle = query.title?.toLowerCase() ?? ''
-        const languages = await getLanguages(this.stateManager)
 
         const results = result.allTitlesViewV2?.allTitlesGroup.flatMap(group => group.titles)
             .filter((title) => title.author?.toLowerCase().includes(ltitle) || title.name.toLowerCase().includes(ltitle))
@@ -312,16 +296,35 @@ export class MangaPlus implements SearchResultsProviding, MangaProviding, Chapte
 
     // Utility
     private async getTitleDetail(mangaId: string): Promise<TitleDetailView> {
+        const language = await this.getPreferredLanguage()
         const request = App.createRequest({
-            url: `${API_URL}/title_detailV3?title_id=${mangaId}&clang=eng`,
+            url: `${API_URL}/title_detailV3?title_id=${mangaId}&clang=${getLanguageCode(language)}`,
             method: 'GET'
         })
 
         const response = await this.requestManager.schedule(request, 1)
-        const result = this.getSuccess(this.decodeResponse(response))
+        const result = this.getSuccess(this.decodeResponse(response), language)
         if (!result.titleDetailView?.title) throw new Error('Cannot find manga')
 
         return result.titleDetailView
+    }
+
+    private async getResultsByLanguage(url: (languageCode: string) => string): Promise<{ languages: Language[]; results: SuccessResult[] }> {
+        const languages = await getLanguages(this.stateManager)
+        const results = await Promise.all(languages.map(async language => {
+            const request = App.createRequest({
+                url: url(getLanguageCode(language)),
+                method: 'GET'
+            })
+            const response = await this.requestManager.schedule(request, 1)
+            return this.getSuccess(this.decodeResponse(response), language)
+        }))
+
+        return { languages, results }
+    }
+
+    private async getPreferredLanguage(): Promise<Language> {
+        return (await getLanguages(this.stateManager))[0] ?? Language.ENGLISH
     }
 
     private decodeResponse(response: Response): MangaPlusResponse {
@@ -329,15 +332,15 @@ export class MangaPlus implements SearchResultsProviding, MangaProviding, Chapte
         return decodeMangaPlusResponse(App.createByteArray(response.rawData))
     }
 
-    private getSuccess(result: MangaPlusResponse) {
+    private getSuccess(result: MangaPlusResponse, language: Language = Language.ENGLISH): SuccessResult {
         if (!result.success) {
-            throw new Error(result.error?.langPopup(Language.ENGLISH)?.body ?? 'Unknown error')
+            throw new Error(result.error?.langPopup(language)?.body ?? 'Unknown error')
         }
 
         return result.success
     }
 
-    private createPartialTitles(items: Title[], languages: string[]): PartialSourceManga[] {
+    private createPartialTitles(items: Title[], languages: Language[]): PartialSourceManga[] {
         const collectedIds = new Set<string>()
         const titles: PartialSourceManga[] = []
 

--- a/src/MangaPlus/MangaPlusHelper.ts
+++ b/src/MangaPlus/MangaPlusHelper.ts
@@ -1,80 +1,72 @@
 import { SourceManga } from '@paperback/types'
 
-
 export interface MangaPlusResponse {
     success?: SuccessResult;
     error?: ErrorResult;
 }
 
-interface SuccessResult {
-    isFeaturedUpdated?: boolean;
-    titleRankingView?: TitleRankingView;
+export interface SuccessResult {
+    titleRankingViewV2?: TitleRankingView;
     titleDetailView?: TitleDetailView;
     mangaViewer?: MangaViewer;
     allTitlesViewV2?: AllTitlesViewV2;
     webHomeViewV4?: WebHomeViewV4;
-    featuredTitlesViewV2?: {
-        contents: [
-            {
-                titleList: {
-                    listName: 'WEEKLY SHONEN JUMP' | 'JUMP PLUS' | 'OTHERS' | 'Re edition' | '"First Read Free" Eligible Titles!';
-                    featuredTitles: Title[];
-                }
-            }
-        ]
-    };
+    featuredTitlesViewV2?: FeaturedTitlesViewV2;
 }
 
-interface TitleRankingView {
+export interface TitleRankingView {
     titles: Title[];
 }
 
-interface AllTitlesViewV2 {
-    AllTitlesGroup: AllTitlesGroup[];
+export interface AllTitlesViewV2 {
+    allTitlesGroup: AllTitlesGroup[];
 }
 
-interface AllTitlesGroup {
-    theTitle: string;
+export interface AllTitlesGroup {
     titles: Title[];
 }
 
-interface WebHomeViewV4 {
-    groups: UpdatedTitleV2Group[];
+export interface WebHomeViewV4 {
+    groups: UpdatedTitleGroup[];
 }
 
-interface UpdatedTitleV2Group {
-    groupName: string;
-    titleGroups: OriginalTitleGroup[];
-}
-
-interface OriginalTitleGroup {
-    theTitle: string;
+export interface UpdatedTitleGroup {
     titles: UpdatedTitle[];
 }
 
-interface UpdatedTitle {
-    title: Title;
+export interface UpdatedTitle {
+    title?: Title;
 }
 
-class ErrorResult {
+export interface FeaturedTitlesViewV2 {
+    contents: FeaturedContent[];
+}
+
+export interface FeaturedContent {
+    titleList?: TitleList;
+}
+
+export interface TitleList {
+    listName: string;
+    featuredTitles: Title[];
+}
+
+export class ErrorResult {
     popups: Popup[] = []
 
     langPopup(lang: Language): Popup | null {
-        return this.popups.find(popup => popup.language === lang) || null
+        return this.popups.find(popup => popup.language === lang)
+            ?? this.popups.find(popup => popup.language === Language.ENGLISH)
+            ?? null
     }
 }
 
-class Popup {
-    subject: string
-    body: string
-    language?: Language
-
-    constructor(subject: string, body: string, language?: Language) {
-        this.subject = subject
-        this.body = body
-        if (language) this.language = language
-        else this.language = Language.ENGLISH
-    }
+export class Popup {
+    constructor(
+        public subject: string,
+        public body: string,
+        public language: Language = Language.ENGLISH
+    ) {}
 }
 
 export enum Language {
@@ -85,108 +77,72 @@ export enum Language {
     PORTUGUESE_BR = 'PORTUGUESE_BR',
     RUSSIAN = 'RUSSIAN',
     THAI = 'THAI',
+    GERMAN = 'GERMAN',
+    ITALIAN = 'ITALIAN',
     VIETNAMESE = 'VIETNAMESE'
 }
 
 export class Title {
-    titleId: number;
-    name: string;
-    author?: string;
-    portraitImageUrl: string;
-    landscapeImageUrl: string;
-    viewCount = 0;
-    language: Language = Language.ENGLISH;
+    viewCount = 0
 
-    constructor(titleId: number, name: string, portraitImageUrl: string, landscapeImageUrl: string, author?: string) {
-        this.titleId = titleId
-        this.name = name
-        this.portraitImageUrl = portraitImageUrl
-        this.landscapeImageUrl = landscapeImageUrl
-
-        if (author) this.author = author
-    }
+    constructor(
+        public titleId: number,
+        public name: string,
+        public portraitImageUrl: string,
+        public landscapeImageUrl: string,
+        public author?: string,
+        public language: Language = Language.ENGLISH
+    ) {}
 }
 
 export class TitleDetailView {
-    title?: Title;
-    titleImageUrl?: string;
-    overview?: string;
-    backgroundImageUrl?: string;
-    nextTimeStamp = 0;
-    viewingPeriodDescription = '';
-    nonAppearanceInfo = '';
-    chapterListGroup: {
-        firstChapterList: Chapter[] | undefined;
-        lastChapterList: Chapter[] | undefined;
-    }[] = [];
-    firstChapterList: Chapter[] = [];
-    lastChapterList: Chapter[] = [];
-    isSimulReleased = false;
-    chaptersDescending = true;
+    title?: Title
+    titleImageUrl?: string
+    overview?: string
+    backgroundImageUrl?: string
+    nextTimeStamp = 0
+    viewingPeriodDescription = ''
+    nonAppearanceInfo = ''
+    firstChapterList: Chapter[] = []
+    lastChapterList: Chapter[] = []
+    isSimulReleased = false
+    tagNames: string[] = []
+
+    private get chapterCount(): number {
+        return this.firstChapterList.length + this.lastChapterList.length
+    }
 
     private get isWebtoon(): boolean {
-        return this.firstChapterList.every(chapter => chapter.isVerticalOnly) && this.lastChapterList.every(chapter => chapter.isVerticalOnly)
+        const chapters = [...this.firstChapterList, ...this.lastChapterList]
+        return chapters.length > 0 && chapters.every(chapter => chapter.isVerticalOnly)
     }
 
     private get isOneShot(): boolean {
-        return this.chapterCount == 1 && this.firstChapterList.at(0)?.name?.localeCompare('one-shot', undefined, { 'sensitivity': 'base' }) == 0
-    }
-
-    private get chapterCount(): number {
-        return this.firstChapterList?.length + this.lastChapterList?.length
+        return this.tagNames.some(tag => tag.toLowerCase() === 'one-shot')
+            || (this.chapterCount === 1
+                && this.firstChapterList[0]?.name?.localeCompare('one-shot', undefined, { sensitivity: 'base' }) === 0)
     }
 
     private get isReEdition(): boolean {
-        return this.viewingPeriodDescription?.search(TitleDetailView.REEDITION_REGEX) != 0
+        return TitleDetailView.REEDITION_REGEX.test(this.viewingPeriodDescription)
     }
 
     private get isCompleted(): boolean {
-        return this.nonAppearanceInfo?.search(TitleDetailView.COMPLETED_REGEX) != 0 || this.isOneShot
+        return TitleDetailView.COMPLETED_REGEX.test(this.nonAppearanceInfo) || this.isOneShot
     }
 
     private get isOnHiatus(): boolean {
-        return this.nonAppearanceInfo?.search(TitleDetailView.HIATUS_REGEX) != 0
+        return TitleDetailView.HIATUS_REGEX.test(this.nonAppearanceInfo)
     }
 
     private get genres(): string[] {
-        const genres = []
+        const genres = [...this.tagNames]
         if (this.isSimulReleased && !this.isReEdition && !this.isOneShot) genres.push('Simulrelease')
-
         if (this.isOneShot) genres.push('One-shot')
-
         if (this.isReEdition) genres.push('Re-edition')
-
         if (this.isWebtoon) genres.push('Webtoon')
 
-        return genres
-    }
-
-    static fromJson(str: string): TitleDetailView {
-        const bopp = JSON.parse(str) as MangaPlusResponse
-
-        if (bopp.success?.titleDetailView === undefined) throw Error('Cannot find manga')
-
-        const json = bopp.success.titleDetailView
-
-        const obj = new TitleDetailView()
-
-        if (json.title === undefined) {
-            throw Error('Cannot find title')
-        }
-
-        const title = json.title
-
-        obj.title = new Title(title.titleId, title.name, title.portraitImageUrl, title.landscapeImageUrl, title.author)
-        obj.titleImageUrl = json.titleImageUrl
-        obj.overview = json.overview
-        obj.backgroundImageUrl = json.backgroundImageUrl
-        obj.nextTimeStamp = json.nextTimeStamp
-        obj.viewingPeriodDescription = json.viewingPeriodDescription
-        obj.nonAppearanceInfo = json.nonAppearanceInfo
-        obj.firstChapterList = json.chapterListGroup?.flatMap(a => a.firstChapterList ?? []).map(chapter => Object.assign(new Chapter(1, 1, '', 1, 1), chapter))
-        obj.lastChapterList = json.chapterListGroup?.flatMap(a => a.lastChapterList ?? []).map(chapter => Object.assign(new Chapter(1, 1, '', 1, 1), chapter))
-        
-        return obj
+        return [...new Set(genres)]
     }
 
     toSourceManga(): SourceManga {
@@ -198,7 +154,7 @@ export class TitleDetailView {
                 titles: [this.title?.name ?? ''],
                 author: authors ? authors[0]?.trimEnd() : this.title?.author ?? '',
                 artist: authors ? authors[1]?.trimStart() : this.title?.author ?? '',
-                desc: (this.overview ?? '') + '\n\n' + (this.viewingPeriodDescription ?? ''),
+                desc: [this.overview, this.viewingPeriodDescription].filter(Boolean).join('\n\n'),
                 tags: [
                     App.createTagSection({
                         id: '0',
@@ -211,44 +167,39 @@ export class TitleDetailView {
         })
     }
 
-    private static COMPLETED_REGEX = /completado|complete|completo/
+    private static COMPLETED_REGEX = /completado|complete|completo/i
     private static HIATUS_REGEX = /on a hiatus/i
-    private static REEDITION_REGEX = /revival|remasterizada/
+    private static REEDITION_REGEX = /revival|remasterizada/i
 }
 
-interface MangaViewer {
+export interface MangaViewer {
     pages: MangaPlusPage[];
     titleId?: number;
-    titleName?: string;
+    viewToken?: string;
 }
 
-interface MangaPlusPage {
+export interface MangaPlusPage {
     mangaPage?: MangaPage;
 }
 
-interface MangaPage {
+export interface MangaPage {
     imageUrl: string;
     width: number;
     height: number;
     encryptionKey?: string;
 }
 
-class Chapter {
-    titleId: number;
-    chapterId: number;
-    name: string;
-    subTitle?: string;
-    startTimeStamp: number;
-    endTimeStamp: number;
-    isVerticalOnly = false;
+export class Chapter {
+    subTitle?: string
+    isVerticalOnly = false
 
-    constructor(titleId: number, chapterId: number, name: string, startTimeStamp: number, endTimeStamp: number) {
-        this.titleId = titleId
-        this.chapterId = chapterId
-        this.name = name
-        this.startTimeStamp = startTimeStamp
-        this.endTimeStamp = endTimeStamp
-    }
+    constructor(
+        public titleId: number,
+        public chapterId: number,
+        public name: string,
+        public startTimeStamp: number,
+        public endTimeStamp: number
+    ) {}
 
     public get isExpired(): boolean {
         return this.subTitle == null
@@ -259,7 +210,7 @@ class Chapter {
 
         return App.createChapter({
             id: this.chapterId.toString(),
-            name: this.subTitle ? this.subTitle : '',
+            name: this.subTitle ?? '',
             chapNum: isNaN(chapNum) ? 0 : chapNum,
             sortingIndex: isNaN(chapNum) ? -1 : chapNum,
             time: new Date(this.startTimeStamp * 1000)

--- a/src/MangaPlus/MangaPlusHelper.ts
+++ b/src/MangaPlus/MangaPlusHelper.ts
@@ -82,6 +82,21 @@ export enum Language {
     VIETNAMESE = 'VIETNAMESE'
 }
 
+export function getLanguageCode(language: Language): string {
+    switch (language) {
+        case Language.SPANISH: return 'esp'
+        case Language.FRENCH: return 'fra'
+        case Language.INDONESIAN: return 'ind'
+        case Language.PORTUGUESE_BR: return 'ptb'
+        case Language.RUSSIAN: return 'rus'
+        case Language.THAI: return 'tha'
+        case Language.GERMAN: return 'deu'
+        case Language.ITALIAN: return 'ita'
+        case Language.VIETNAMESE: return 'vie'
+        default: return 'eng'
+    }
+}
+
 export class Title {
     viewCount = 0
 

--- a/src/MangaPlus/MangaPlusProto.ts
+++ b/src/MangaPlus/MangaPlusProto.ts
@@ -1,0 +1,684 @@
+import { Buffer } from 'buffer'
+
+import {
+    AllTitlesGroup,
+    Chapter,
+    ErrorResult,
+    FeaturedContent,
+    FeaturedTitlesViewV2,
+    Language,
+    MangaPage,
+    MangaPlusPage,
+    MangaPlusResponse,
+    MangaViewer,
+    Popup,
+    SuccessResult,
+    Title,
+    TitleDetailView,
+    TitleList,
+    UpdatedTitle,
+    UpdatedTitleGroup,
+    WebHomeViewV4
+} from './MangaPlusHelper'
+
+class ProtoReader {
+    private position = 0
+
+    constructor(private readonly bytes: Uint8Array) {}
+
+    get done(): boolean {
+        return this.position >= this.bytes.length
+    }
+
+    readTag(): { fieldNumber: number; wireType: number } {
+        const tag = this.readVarint()
+        return {
+            fieldNumber: Math.floor(tag / 8),
+            wireType: tag % 8
+        }
+    }
+
+    readVarint(): number {
+        let value = 0
+        let multiplier = 1
+
+        for (let index = 0; index < 10; index++) {
+            const byte = this.bytes[this.position++]
+            if (byte === undefined) throw new Error('Unexpected end of protobuf varint')
+
+            value += (byte & 0x7f) * multiplier
+            if ((byte & 0x80) === 0) return value
+
+            multiplier *= 128
+        }
+
+        throw new Error('Invalid protobuf varint')
+    }
+
+    readBytes(): Uint8Array {
+        const length = this.readVarint()
+        const end = this.position + length
+        if (end > this.bytes.length) throw new Error('Unexpected end of protobuf message')
+
+        const value = this.bytes.subarray(this.position, end)
+        this.position = end
+        return value
+    }
+
+    readString(): string {
+        return Buffer.from(this.readBytes()).toString('utf8')
+    }
+
+    skip(wireType: number): void {
+        switch (wireType) {
+            case 0:
+                this.readVarint()
+                return
+            case 1:
+                this.position += 8
+                break
+            case 2:
+                {
+                    const length = this.readVarint()
+                    this.position += length
+                }
+                break
+            case 5:
+                this.position += 4
+                break
+            default:
+                throw new Error(`Unsupported protobuf wire type ${wireType} at byte ${this.position}`)
+        }
+
+        if (this.position > this.bytes.length) throw new Error('Unexpected end of protobuf field')
+    }
+}
+
+function readNested<T>(reader: ProtoReader, decoder: (bytes: Uint8Array) => T, wireType: number): T | undefined {
+    if (wireType !== 2) {
+        reader.skip(wireType)
+        return undefined
+    }
+
+    try {
+        return decoder(reader.readBytes())
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        throw new Error(`${decoder.name}: ${message}`)
+    }
+}
+
+function languageFromCode(code: number): Language {
+    switch (code) {
+        case 1: return Language.SPANISH
+        case 2: return Language.FRENCH
+        case 3: return Language.INDONESIAN
+        case 4: return Language.PORTUGUESE_BR
+        case 5: return Language.RUSSIAN
+        case 6: return Language.THAI
+        case 7: return Language.GERMAN
+        case 8: return Language.ITALIAN
+        case 9: return Language.VIETNAMESE
+        default: return Language.ENGLISH
+    }
+}
+
+function decodePopup(bytes: Uint8Array, fallbackLanguage: Language): Popup {
+    const reader = new ProtoReader(bytes)
+    let subject = ''
+    let body = ''
+    let language = fallbackLanguage
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        switch (fieldNumber) {
+            case 1:
+                subject = wireType === 2 ? reader.readString() : subject
+                if (wireType !== 2) reader.skip(wireType)
+                break
+            case 2:
+                body = wireType === 2 ? reader.readString() : body
+                if (wireType !== 2) reader.skip(wireType)
+                break
+            case 6:
+                language = wireType === 0 ? languageFromCode(reader.readVarint()) : language
+                if (wireType !== 0) reader.skip(wireType)
+                break
+            default:
+                reader.skip(wireType)
+        }
+    }
+
+    return new Popup(subject, body, language)
+}
+
+function decodeError(bytes: Uint8Array): ErrorResult {
+    const reader = new ProtoReader(bytes)
+    const error = new ErrorResult()
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        const fallbackLanguage = fieldNumber === 3 ? Language.SPANISH : Language.ENGLISH
+
+        if (fieldNumber === 2 || fieldNumber === 3 || fieldNumber === 5) {
+            const popup = readNested(reader, bytes => decodePopup(bytes, fallbackLanguage), wireType)
+            if (popup) error.popups.push(popup)
+        } else {
+            reader.skip(wireType)
+        }
+    }
+
+    return error
+}
+
+function decodeTitle(bytes: Uint8Array): Title {
+    const reader = new ProtoReader(bytes)
+    let titleId = 0
+    let name = ''
+    let author: string | undefined
+    let portraitImageUrl = ''
+    let landscapeImageUrl = ''
+    let language = Language.ENGLISH
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        switch (fieldNumber) {
+            case 1:
+                titleId = wireType === 0 ? reader.readVarint() : titleId
+                if (wireType !== 0) reader.skip(wireType)
+                break
+            case 2:
+                name = wireType === 2 ? reader.readString() : name
+                if (wireType !== 2) reader.skip(wireType)
+                break
+            case 3:
+                author = wireType === 2 ? reader.readString() : author
+                if (wireType !== 2) reader.skip(wireType)
+                break
+            case 4:
+                portraitImageUrl = wireType === 2 ? reader.readString() : portraitImageUrl
+                if (wireType !== 2) reader.skip(wireType)
+                break
+            case 5:
+                landscapeImageUrl = wireType === 2 ? reader.readString() : landscapeImageUrl
+                if (wireType !== 2) reader.skip(wireType)
+                break
+            case 7:
+                language = wireType === 0 ? languageFromCode(reader.readVarint()) : language
+                if (wireType !== 0) reader.skip(wireType)
+                break
+            default:
+                reader.skip(wireType)
+        }
+    }
+
+    return new Title(titleId, name, portraitImageUrl, landscapeImageUrl, author, language)
+}
+
+function decodeChapter(bytes: Uint8Array): Chapter {
+    const reader = new ProtoReader(bytes)
+    let titleId = 0
+    let chapterId = 0
+    let name = ''
+    let subTitle: string | undefined
+    let startTimeStamp = 0
+    let endTimeStamp = 0
+    let isVerticalOnly = false
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        switch (fieldNumber) {
+            case 1:
+                titleId = wireType === 0 ? reader.readVarint() : titleId
+                if (wireType !== 0) reader.skip(wireType)
+                break
+            case 2:
+                chapterId = wireType === 0 ? reader.readVarint() : chapterId
+                if (wireType !== 0) reader.skip(wireType)
+                break
+            case 3:
+                name = wireType === 2 ? reader.readString() : name
+                if (wireType !== 2) reader.skip(wireType)
+                break
+            case 4:
+                subTitle = wireType === 2 ? reader.readString() : subTitle
+                if (wireType !== 2) reader.skip(wireType)
+                break
+            case 6:
+                startTimeStamp = wireType === 0 ? reader.readVarint() : startTimeStamp
+                if (wireType !== 0) reader.skip(wireType)
+                break
+            case 7:
+                endTimeStamp = wireType === 0 ? reader.readVarint() : endTimeStamp
+                if (wireType !== 0) reader.skip(wireType)
+                break
+            case 9:
+                isVerticalOnly = wireType === 0 ? reader.readVarint() !== 0 : isVerticalOnly
+                if (wireType !== 0) reader.skip(wireType)
+                break
+            default:
+                reader.skip(wireType)
+        }
+    }
+
+    const chapter = new Chapter(titleId, chapterId, name, startTimeStamp, endTimeStamp)
+    chapter.subTitle = subTitle
+    chapter.isVerticalOnly = isVerticalOnly
+    return chapter
+}
+
+function decodeChapterGroup(bytes: Uint8Array): { first: Chapter[]; last: Chapter[] } {
+    const reader = new ProtoReader(bytes)
+    const first: Chapter[] = []
+    const last: Chapter[] = []
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        if (fieldNumber === 2 || fieldNumber === 4) {
+            const chapter = readNested(reader, decodeChapter, wireType)
+            if (chapter) (fieldNumber === 2 ? first : last).push(chapter)
+        } else {
+            reader.skip(wireType)
+        }
+    }
+
+    return { first, last }
+}
+
+function decodeTagName(bytes: Uint8Array): string {
+    const reader = new ProtoReader(bytes)
+    let name = ''
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        if (fieldNumber === 1 && wireType === 2) {
+            name = reader.readString()
+        } else {
+            reader.skip(wireType)
+        }
+    }
+
+    return name
+}
+
+function decodeTitleDetail(bytes: Uint8Array): TitleDetailView {
+    const reader = new ProtoReader(bytes)
+    const detail = new TitleDetailView()
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        switch (fieldNumber) {
+            case 1:
+                detail.title = readNested(reader, decodeTitle, wireType) ?? detail.title
+                break
+            case 2:
+                detail.titleImageUrl = wireType === 2 ? reader.readString() : detail.titleImageUrl
+                if (wireType !== 2) reader.skip(wireType)
+                break
+            case 3:
+                detail.overview = wireType === 2 ? reader.readString() : detail.overview
+                if (wireType !== 2) reader.skip(wireType)
+                break
+            case 4:
+                detail.backgroundImageUrl = wireType === 2 ? reader.readString() : detail.backgroundImageUrl
+                if (wireType !== 2) reader.skip(wireType)
+                break
+            case 5:
+                detail.nextTimeStamp = wireType === 0 ? reader.readVarint() : detail.nextTimeStamp
+                if (wireType !== 0) reader.skip(wireType)
+                break
+            case 7:
+                detail.viewingPeriodDescription = wireType === 2 ? reader.readString() : detail.viewingPeriodDescription
+                if (wireType !== 2) reader.skip(wireType)
+                break
+            case 8:
+                detail.nonAppearanceInfo = wireType === 2 ? reader.readString() : detail.nonAppearanceInfo
+                if (wireType !== 2) reader.skip(wireType)
+                break
+            case 14:
+                detail.isSimulReleased = wireType === 0 ? reader.readVarint() !== 0 : detail.isSimulReleased
+                if (wireType !== 0) reader.skip(wireType)
+                break
+            case 28: {
+                const group = readNested(reader, decodeChapterGroup, wireType)
+                if (group) {
+                    detail.firstChapterList.push(...group.first)
+                    detail.lastChapterList.push(...group.last)
+                }
+                break
+            }
+            case 31: {
+                const tagName = readNested(reader, decodeTagName, wireType)
+                if (tagName) detail.tagNames.push(tagName)
+                break
+            }
+            default:
+                reader.skip(wireType)
+        }
+    }
+
+    return detail
+}
+
+function decodeMangaPage(bytes: Uint8Array): MangaPage {
+    const reader = new ProtoReader(bytes)
+    let imageUrl = ''
+    let width = 0
+    let height = 0
+    let encryptionKey: string | undefined
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        switch (fieldNumber) {
+            case 1:
+                imageUrl = wireType === 2 ? reader.readString() : imageUrl
+                if (wireType !== 2) reader.skip(wireType)
+                break
+            case 2:
+                width = wireType === 0 ? reader.readVarint() : width
+                if (wireType !== 0) reader.skip(wireType)
+                break
+            case 3:
+                height = wireType === 0 ? reader.readVarint() : height
+                if (wireType !== 0) reader.skip(wireType)
+                break
+            case 5:
+                encryptionKey = wireType === 2 ? reader.readString() : encryptionKey
+                if (wireType !== 2) reader.skip(wireType)
+                break
+            default:
+                reader.skip(wireType)
+        }
+    }
+
+    return { imageUrl, width, height, encryptionKey }
+}
+
+function decodePage(bytes: Uint8Array): MangaPlusPage {
+    const reader = new ProtoReader(bytes)
+    let mangaPage: MangaPage | undefined
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        if (fieldNumber === 1) {
+            mangaPage = readNested(reader, decodeMangaPage, wireType) ?? mangaPage
+        } else {
+            reader.skip(wireType)
+        }
+    }
+
+    return { mangaPage }
+}
+
+function decodeMangaViewer(bytes: Uint8Array): MangaViewer {
+    const reader = new ProtoReader(bytes)
+    const viewer: MangaViewer = { pages: [] }
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        switch (fieldNumber) {
+            case 1: {
+                const page = readNested(reader, decodePage, wireType)
+                if (page) viewer.pages.push(page)
+                break
+            }
+            case 9:
+                viewer.titleId = wireType === 0 ? reader.readVarint() : viewer.titleId
+                if (wireType !== 0) reader.skip(wireType)
+                break
+            case 19:
+                viewer.viewToken = wireType === 2 ? reader.readString() : viewer.viewToken
+                if (wireType !== 2) reader.skip(wireType)
+                break
+            default:
+                reader.skip(wireType)
+        }
+    }
+
+    return viewer
+}
+
+function decodeAllTitlesGroup(bytes: Uint8Array): AllTitlesGroup {
+    const reader = new ProtoReader(bytes)
+    const group: AllTitlesGroup = { titles: [] }
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        if (fieldNumber === 2) {
+            const title = readNested(reader, decodeTitle, wireType)
+            if (title) group.titles.push(title)
+        } else {
+            reader.skip(wireType)
+        }
+    }
+
+    return group
+}
+
+function decodeAllTitlesViewV2(bytes: Uint8Array): { allTitlesGroup: AllTitlesGroup[] } {
+    const reader = new ProtoReader(bytes)
+    const allTitlesGroup: AllTitlesGroup[] = []
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        if (fieldNumber === 1) {
+            const group = readNested(reader, decodeAllTitlesGroup, wireType)
+            if (group) allTitlesGroup.push(group)
+        } else {
+            reader.skip(wireType)
+        }
+    }
+
+    return { allTitlesGroup }
+}
+
+function decodeTitleRankingGroup(bytes: Uint8Array): Title[] {
+    const reader = new ProtoReader(bytes)
+    const titles: Title[] = []
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        if (fieldNumber === 2) {
+            const title = readNested(reader, decodeTitle, wireType)
+            if (title) titles.push(title)
+        } else {
+            reader.skip(wireType)
+        }
+    }
+
+    return titles
+}
+
+function decodeTitleRankingViewV2(bytes: Uint8Array): { titles: Title[] } {
+    const reader = new ProtoReader(bytes)
+    const titles: Title[] = []
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        if (fieldNumber === 3) {
+            const groupTitles = readNested(reader, decodeTitleRankingGroup, wireType)
+            if (groupTitles) titles.push(...groupTitles)
+        } else {
+            reader.skip(wireType)
+        }
+    }
+
+    return { titles }
+}
+
+function decodeLatestChapter(bytes: Uint8Array): Title | undefined {
+    const reader = new ProtoReader(bytes)
+    let title: Title | undefined
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        if (fieldNumber === 1) {
+            title = readNested(reader, decodeTitle, wireType) ?? title
+        } else {
+            reader.skip(wireType)
+        }
+    }
+
+    return title
+}
+
+function decodeUpdatedTitle(bytes: Uint8Array): UpdatedTitle {
+    const reader = new ProtoReader(bytes)
+    let title: Title | undefined
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        if (fieldNumber === 3) {
+            title = readNested(reader, decodeLatestChapter, wireType) ?? title
+        } else {
+            reader.skip(wireType)
+        }
+    }
+
+    return { title }
+}
+
+function decodeUpdatedTitleGroup(bytes: Uint8Array): UpdatedTitleGroup {
+    const reader = new ProtoReader(bytes)
+    const group: UpdatedTitleGroup = { titles: [] }
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        if (fieldNumber === 2) {
+            const title = readNested(reader, decodeUpdatedTitle, wireType)
+            if (title) group.titles.push(title)
+        } else {
+            reader.skip(wireType)
+        }
+    }
+
+    return group
+}
+
+function decodeWebHomeViewV4(bytes: Uint8Array): WebHomeViewV4 {
+    const reader = new ProtoReader(bytes)
+    const view: WebHomeViewV4 = { groups: [] }
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        if (fieldNumber === 2) {
+            const group = readNested(reader, decodeUpdatedTitleGroup, wireType)
+            if (group) view.groups.push(group)
+        } else {
+            reader.skip(wireType)
+        }
+    }
+
+    return view
+}
+
+function decodeTitleList(bytes: Uint8Array): TitleList {
+    const reader = new ProtoReader(bytes)
+    const titleList: TitleList = { listName: '', featuredTitles: [] }
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        switch (fieldNumber) {
+            case 1:
+                titleList.listName = wireType === 2 ? reader.readString() : titleList.listName
+                if (wireType !== 2) reader.skip(wireType)
+                break
+            case 2: {
+                const title = readNested(reader, decodeTitle, wireType)
+                if (title) titleList.featuredTitles.push(title)
+                break
+            }
+            default:
+                reader.skip(wireType)
+        }
+    }
+
+    return titleList
+}
+
+function decodeFeaturedContent(bytes: Uint8Array): FeaturedContent {
+    const reader = new ProtoReader(bytes)
+    const content: FeaturedContent = {}
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        if (fieldNumber === 2) {
+            content.titleList = readNested(reader, decodeTitleList, wireType) ?? content.titleList
+        } else {
+            reader.skip(wireType)
+        }
+    }
+
+    return content
+}
+
+function decodeFeaturedTitlesViewV2(bytes: Uint8Array): FeaturedTitlesViewV2 {
+    const reader = new ProtoReader(bytes)
+    const view: FeaturedTitlesViewV2 = { contents: [] }
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        if (fieldNumber === 2) {
+            const content = readNested(reader, decodeFeaturedContent, wireType)
+            if (content) view.contents.push(content)
+        } else {
+            reader.skip(wireType)
+        }
+    }
+
+    return view
+}
+
+function decodeSuccess(bytes: Uint8Array): SuccessResult {
+    const reader = new ProtoReader(bytes)
+    const success: SuccessResult = {}
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        switch (fieldNumber) {
+            case 8:
+                success.titleDetailView = readNested(reader, decodeTitleDetail, wireType) ?? success.titleDetailView
+                break
+            case 10:
+                success.mangaViewer = readNested(reader, decodeMangaViewer, wireType) ?? success.mangaViewer
+                break
+            case 25:
+                success.allTitlesViewV2 = readNested(reader, decodeAllTitlesViewV2, wireType) ?? success.allTitlesViewV2
+                break
+            case 37:
+                success.titleRankingViewV2 = readNested(reader, decodeTitleRankingViewV2, wireType) ?? success.titleRankingViewV2
+                break
+            case 38:
+                success.webHomeViewV4 = readNested(reader, decodeWebHomeViewV4, wireType) ?? success.webHomeViewV4
+                break
+            case 39:
+                success.featuredTitlesViewV2 = readNested(reader, decodeFeaturedTitlesViewV2, wireType) ?? success.featuredTitlesViewV2
+                break
+            default:
+                reader.skip(wireType)
+        }
+    }
+
+    return success
+}
+
+export function decodeMangaPlusResponse(bytes: Uint8Array): MangaPlusResponse {
+    const reader = new ProtoReader(bytes)
+    const response: MangaPlusResponse = {}
+
+    while (!reader.done) {
+        const { fieldNumber, wireType } = reader.readTag()
+        switch (fieldNumber) {
+            case 1:
+                response.success = readNested(reader, decodeSuccess, wireType) ?? response.success
+                break
+            case 2:
+                response.error = readNested(reader, decodeError, wireType) ?? response.error
+                break
+            default:
+                reader.skip(wireType)
+        }
+    }
+
+    return response
+}

--- a/src/MangaPlus/MangaPlusSettings.ts
+++ b/src/MangaPlus/MangaPlusSettings.ts
@@ -6,8 +6,9 @@ import {
 
 import { Language } from './MangaPlusHelper'
 
-export const getLanguages = async (stateManager: SourceStateManager): Promise<string[]> => {
-    return (await stateManager.retrieve('languages') as string[]) ?? [Language.ENGLISH]
+export const getLanguages = async (stateManager: SourceStateManager): Promise<Language[]> => {
+    const languages = await stateManager.retrieve('languages') as Language[] | undefined
+    return languages?.length ? [...new Set(languages)] : [Language.ENGLISH]
 }
 
 export const getSplitImages = async (stateManager: SourceStateManager): Promise<string> => {
@@ -41,7 +42,7 @@ export const contentSettings = (stateManager: SourceStateManager): DUINavigation
                                 App.createDUISelect({
                                     id: 'languages',
                                     label: 'Languages',
-                                    options: [Language.ENGLISH, Language.FRENCH, Language.INDONESIAN, Language.PORTUGUESE_BR, Language.RUSSIAN, Language.SPANISH, Language.THAI, Language.VIETNAMESE],
+                                    options: [Language.ENGLISH, Language.SPANISH, Language.FRENCH, Language.INDONESIAN, Language.PORTUGUESE_BR, Language.RUSSIAN, Language.THAI, Language.VIETNAMESE, Language.GERMAN],
                                     labelResolver: async (option: string) => {
                                         switch (option) {
                                             case Language.ENGLISH:
@@ -67,6 +68,9 @@ export const contentSettings = (stateManager: SourceStateManager): DUINavigation
 
                                             case Language.VIETNAMESE:
                                                 return 'Tiếng Việt'
+
+                                            case Language.GERMAN:
+                                                return 'Deutsch'
 
                                             default:
                                                 return ''


### PR DESCRIPTION
## Summary

- Decode Manga Plus application/x-protobuf responses after the JSON endpoints began returning HTML 403 responses.
- Move ranking and reader requests to the current API endpoints and forward the session and Plus-Vw-Token headers required by secured pages.
- Decrypt reader images in place for Paperback 0.8 and support iOS-escaped fragment metadata.
- Preserve language filtering, title metadata, chapter parsing, and search while using a moderate five-request-per-second limit.

## Testing

- npm test -- MangaPlus --use-node-fs: all five live integration checks pass.
- npm run bundle -- --folder=protobuf-test: bundle succeeds.
- Paperback iPhone debugger: homepage, manga details, chapters, and chapter details pass on device.
- Manual secured-reader test: CDN images return 200 and display after XOR decryption.
- ESLint on all MangaPlus files: zero errors; three existing interface-signature warnings remain.